### PR TITLE
Allow handlers to send multiple messages to the client in a handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meows"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["R. Tyler Croy <rtyler@brokenco.de>"]
 edition = "2018"
 description = "A simple pattern for async service messaging over WebSockets"
@@ -11,6 +11,7 @@ keywords = ["websocket", "async"]
 readme = "README.md"
 
 [dependencies]
+async-channel = "~1.1.1"
 async-tungstenite = "~0.5.0"
 futures = "~0.3.5"
 log = "~0.4.8"

--- a/examples/multisend.rs
+++ b/examples/multisend.rs
@@ -1,0 +1,60 @@
+/**
+ * The multisend example demonstrates how the server can send multiple responses
+ * for a single inbound message
+ */
+
+#[macro_use]
+extern crate meows;
+extern crate pretty_env_logger;
+#[macro_use]
+extern crate serde_derive;
+
+use meows::*;
+use smol;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Ping {
+    msg: String,
+}
+
+/**
+ * Handle ping messages, just send a pong back
+ */
+async fn handle_ping(mut req: Request<(), ()>) -> Option<Message> {
+    if let Some(ping) = req.from_value::<Ping>() {
+        info!("Ping received with message: {}", ping.msg);
+
+        for i in 1..5 {
+            req.sink.send(
+                Message::text(format!("pong {}", i))
+            ).await;
+
+        }
+    }
+    None
+}
+
+/**
+ * The default handler for unknown strings is to do nothing,
+ * this handler will instead send whatever message we get back to the client
+ */
+async fn default_echo(message: String, _state: Arc<()>) -> Option<Message> {
+    info!("Default echo: {}", message);
+    Some(Message::text(message))
+}
+
+/**
+ * THe main is pretty simple, just fire up the Meows server and set the handlers
+ */
+fn main() -> Result<(), std::io::Error> {
+    pretty_env_logger::init();
+
+    println!("Starting simple ping/pong websocket server with meows");
+    let mut server = meows::Server::new();
+
+    server.default(default_echo);
+    server.on("ping", handle_ping);
+
+    smol::run(async move { server.serve("127.0.0.1:8105".to_string()).await })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub struct Request<ServerState, ClientState> {
     pub env: Envelope,
     pub state: Arc<ServerState>,
     pub client_state: Arc<RwLock<ClientState>>,
+    pub sink: async_channel::Sender<Message>,
 }
 
 impl<ServerState, ClientState> Request<ServerState, ClientState> {
@@ -245,12 +246,30 @@ impl<ServerState: 'static + Send + Sync, ClientState: 'static + Default + Send +
         state: Arc<ServerState>,
         default: DefaultCallback<ServerState, ClientState>,
         handlers: Arc<RwLock<HashMap<String, Callback<ServerState, ClientState>>>>,
-        mut stream: WebSocketStream<Async<TcpStream>>,
+        stream: WebSocketStream<Async<TcpStream>>,
     ) -> Result<(), std::io::Error> {
 
         let client_state = Arc::new(RwLock::new(ClientState::default()));
 
-        while let Some(raw) = stream.next().await {
+        /*
+         * The WebSocketStream must be split into the reader and writer since
+         * Meows intentionally decouples reading from writing.
+         *
+         * This allows for passing a handler an channel sink with which it can
+         * send _multiple_ messages, not just the Message returned by the handler
+         * function itself.
+         */
+        let (mut writer, mut reader) = stream.split();
+        let (channel_tx, channel_rx) = async_channel::unbounded::<Message>();
+
+        Task::spawn(async move {
+            while let Ok(outgoing) = channel_rx.recv().await {
+                trace!("Must send {:?} to the socket", outgoing);
+                writer.send(outgoing).await;
+            }
+        }).detach();
+
+        while let Some(raw) = reader.next().await {
             let client_state = client_state.clone();
 
             trace!("WebSocket message received: {:?}", raw);
@@ -278,15 +297,16 @@ impl<ServerState: 'static + Send + Sync, ClientState: 'static + Default + Send +
                                 env: envelope,
                                 state: state.clone(),
                                 client_state: client_state.clone(),
+                                sink: channel_tx.clone(),
                             };
 
                             if let Some(response) = handler.call(req).await {
-                                stream.send(response).await;
+                                channel_tx.send(response).await;
                             }
                         }
                     } else {
                         if let Some(response) = default.call(message, state.clone()).await {
-                            stream.send(response).await;
+                            channel_tx.send(response).await;
                         }
                     }
                 }


### PR DESCRIPTION
The challenge:  multi-plexing the reads/writes on this websocket to allow·messages to be sent to the `stream` after the handler has already been invoked. In effect, allowing another async task to send a message along for the websocket to write out·         