### PR TITLE
Add support for sending a termination signal to the server loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["websocket", "async"]
 readme = "README.md"
 
 [dependencies]
-async-channel = "~1.1.1"
 async-tungstenite = "~0.5.0"
 futures = "~0.3.5"
 log = "~0.4.8"


### PR DESCRIPTION
See examples/terminate.rs, but this basically allows for using Meows easily
inside of a test infrastructure.